### PR TITLE
Fix Pages deployment action version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v1
         with:
           path: './docs'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- use existing `actions/upload-pages-artifact@v1` in Pages workflow

## Testing
- `python -m py_compile api_tester.py`


------
https://chatgpt.com/codex/tasks/task_e_689dd9d3cd508324bb156d3f41076bcc