### PR TITLE
Update Pages artifact action version to fix deprecation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './docs'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- fix failing workflows by using `actions/upload-pages-artifact@v3`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ddb8ff2988324a6f6bf016a408c61