### PR TITLE
ci: ensure nojekyll for Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Ensure .nojekyll
+        run: touch docs/.nojekyll
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- ensure .nojekyll file exists before deploying to GitHub Pages

## Testing
- `python -m py_compile api_tester.py`


------
https://chatgpt.com/codex/tasks/task_e_689de33b29408324a0cc76126c20e4c2