### PR TITLE
Enable Pages auto-enable in workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,10 +23,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
       - name: Ensure .nojekyll
         run: touch docs/.nojekyll
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: enable
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- allow the configure-pages action to auto-enable Pages via the `enablement` input
- set up latest Python runtime for the Pages workflow

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689de4db5e7483249b52cf28e2e8cef7