### PR TITLE
fix: add token for configure-pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           enablement: enable
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- supply GITHUB_TOKEN to `actions/configure-pages@v5`

## Testing
- `python api_tester.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_689de6d9b2b883249e0aa21e679ca80f