### PR TITLE
Add Railway deployment files

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python api_tester.py --ui --port $PORT

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ A simple repository for testing APIs.
 
 The static site is served from the `docs` directory and includes a `.nojekyll`
 file to bypass Jekyll processing.
+
+## Deployment
+
+The project includes a minimal `requirements.txt` and `Procfile` so it can be
+deployed on platforms like [Railway](https://railway.app) using Nixpacks.
+`Procfile` starts the Flask UI with `python api_tester.py --ui --port $PORT`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests


### PR DESCRIPTION
## Summary
- add requirements and Procfile so Nixpacks can build and run the app on Railway
- document deployment with Railway and Nixpacks

## Testing
- `python -m py_compile api_tester.py`
- `python -m pip install -r requirements.txt` *(fails: ProxyError 403 when fetching Flask)*
- `python api_tester.py --help` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_689df58b427c8324b2913849ff9e6f77