### PR TITLE
feat: add script downloader and token cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ file to bypass Jekyll processing.
 The project includes a minimal `requirements.txt` and `Procfile` so it can be
 deployed on platforms like [Railway](https://railway.app) using Nixpacks.
 `Procfile` starts the Flask UI with `python api_tester.py --ui --port $PORT`.
+
+## Local test script download
+
+Use `python api_tester.py --download <URL>` to fetch a helper script and
+Markdown instructions for running API checks locally. If the remote server
+requires authentication, supply `--token <YOUR_TOKEN>` and the token will be
+cached until the server rejects it.
+
+## Authorization token caching
+
+When running tests, an `Authorization` header found in the cURL command or
+provided via `--token` is remembered and automatically applied to subsequent
+requests. The cache is cleared after a `401` or `403` response.


### PR DESCRIPTION
## Summary
- support downloading a helper script plus instructions for local API testing
- add optional Authorization token with automatic caching and clearing on 401/403

## Testing
- `python -m py_compile api_tester.py`
- `python api_tester.py --help`
- `python api_tester.py --curl "curl -X GET https://httpbin.org/status/200" --timeout 5`
- `python api_tester.py --download https://httpbin.org/get` *(fails: HTTPSConnectionPool - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689df876e1c08324a9ae36a389f0b1ce